### PR TITLE
Badge to show you’re free of known vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/matt-major/do-wrapper.svg?branch=master)](https://travis-ci.org/matt-major/do-wrapper)
 [![Dependencies](https://david-dm.org/matt-major/do-wrapper.svg)](https://www.npmjs.com/package/do-wrapper)
 [![Downloads](https://img.shields.io/npm/dm/do-wrapper.svg)](https://www.npmjs.com/package/do-wrapper)
+[![Known Vulnerabilities](https://snyk.io/test/github/matt-major/do-wrapper/ec7006219fc32dfd29513c889215cb1065376738/badge.svg)](https://snyk.io/test/github/matt-major/do-wrapper/ec7006219fc32dfd29513c889215cb1065376738)
 
 ### Install
 


### PR DESCRIPTION
do-wrapper has no vulnerabilities, which is awesome! 

This PR adds a badge that shows you’re free of known vulnerabilities. Note that the badge works off the latest master branch.

Adding the badge will show others that you care about security, and that they should care, too. 
(It will also help to spread the word about Snyk, which would benefit us a lot!). 
 
Check our [documentation](https://snyk.io/docs/badges/#github-badge) if you’d like to know more about our badges. 

Stay secure, 
The Snyk team